### PR TITLE
Fix issue with id() precision in JS

### DIFF
--- a/API.md
+++ b/API.md
@@ -79,9 +79,9 @@ Returns the stringification of this point as an array.
 longitude, stored internally as [radians](http://en.wikipedia.org/wiki/Radian)
 rather than degrees..
 
-## latLng.lat() -> number
+## latLng.lat -> number
 
-## latLng.lng() -> number
+## latLng.lng -> number
 
 ## latLng.isValid() -> boolean
 

--- a/src/cellid.cc
+++ b/src/cellid.cc
@@ -203,7 +203,9 @@ void CellId::Contains(const FunctionCallbackInfo<Value>& args) {
 void CellId::Id(const FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = args.GetIsolate();
     CellId* obj = node::ObjectWrap::Unwrap<CellId>(args.Holder());
-    args.GetReturnValue().Set(Number::New(isolate,obj->this_.id()));
+    char str[21];
+    sprintf(str, "%llu", obj->this_.id());
+    args.GetReturnValue().Set(String::NewFromUtf8(isolate,str));
 }
 
 void CellId::IdString(const FunctionCallbackInfo<Value>& args){


### PR DESCRIPTION
JS can only accurately represent numbers up 53-bits. After that you're in floating point territory which means the ids returned from this function are corrupted.

```
> 1921535845664292864
1921535845664292900 # least significant bits are lost
```

There's two options.. you can use [long.js](https://www.npmjs.com/package/long) or just return strings. There seems to be few use cases for performing math directly on a cell id so I went with returning a string instead.
